### PR TITLE
Systemd: Removed unionfs.service from after.

### DIFF
--- a/systemd/cloudplow.service
+++ b/systemd/cloudplow.service
@@ -2,7 +2,7 @@
 
 [Unit]
 Description=cloudplow
-After=network-online.target unionfs.service
+After=network-online.target
 
 [Service]
 User=seed


### PR DESCRIPTION
- Not everyone will have unionfs setup.
- Also for ones that do have unionfs setup, they will be using the a non-union path anyway (eg /mnt/local/)