### PR TITLE
Added ability to disable throttles on a per-uploader basis.

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ Cloudplow has 3 main functions:
     },
     "uploader": {
         "google": {
+            "can_be_throttled": true,
             "check_interval": 30,
             "exclude_open_files": true,
             "max_size_gb": 400,
@@ -739,6 +740,7 @@ If multiple uploader tasks are specified, the tasks will run sequentially (vs in
 ```
 "uploader": {
     "google": {
+        "can_be_throttled": true,
         "check_interval": 30,
         "exclude_open_files": true,
         "max_size_gb": 500,
@@ -759,6 +761,8 @@ If multiple uploader tasks are specified, the tasks will run sequentially (vs in
 ```
 
 In the example above, the uploader references `"google"` from the `remotes` section.
+
+`"can_be_throttled"`: When this attribute is missing or set to `true`, this uploader can be throttled if enabled in the Plex config section. When set to `false`, no throttling will be attempted on this uploader.
 
 `"check_interval"`: How often (in minutes) to check the size of this remotes `upload_folder`. Once it reaches the size threshold as specified in `max_size_gb`, the uploader will start.
 

--- a/cloudplow.py
+++ b/cloudplow.py
@@ -259,9 +259,14 @@ def do_upload(remote=None):
                 notify.send(message="Upload of %d GB has begun for remote: %s" % (
                     path.get_size(rclone_config['upload_folder'], uploader_config['size_excludes']), uploader_remote))
 
-                # start the plex stream monitor before the upload begins, if enabled
+                # start the plex stream monitor before the upload begins, if enabled for both plex and the uploader
                 if conf.configs['plex']['enabled'] and plex_monitor_thread is None:
-                    plex_monitor_thread = thread.start(do_plex_monitor, 'plex-monitor')
+                    # Only disable throttling if 'can_be_throttled' is both present in uploader_config and is set to False.
+                    if 'can_be_throttled' in uploader_config and not uploader_config['can_be_throttled']:
+                        log.debug("Skipping check for Plex stream due to throttling disabled in remote: %s", uploader_remote)
+                    # Otherwise, assume throttling is desired.
+                    else:
+                        plex_monitor_thread = thread.start(do_plex_monitor, 'plex-monitor')
 
                 # pause the nzbget queue before starting the upload, if enabled
                 if conf.configs['nzbget']['enabled']:

--- a/config.json.sample
+++ b/config.json.sample
@@ -78,6 +78,7 @@
     },
     "uploader": {
         "google": {
+            "can_be_throttled": true,
             "check_interval": 30,
             "exclude_open_files": true,
             "max_size_gb": 200,

--- a/utils/config.py
+++ b/utils/config.py
@@ -142,6 +142,7 @@ class Config(object):
         # add example uploader
         cfg['uploader'] = {
             'google': {
+                'can_be_throttled': True,
                 'check_interval': 30,
                 'max_size_gb': 200,
                 'size_excludes': [


### PR DESCRIPTION
New uploader config attribute "can_be_throttled" if present and set to
false will disable throttling for that uploader.

My use case for this is an upload job that runs very quickly, and the 15 second sleep in the Plex monitor thread takes long enough that rclone has already finished executing and the rclone RC URL validation will fail since rclone is no longer listening. I still want throttling enabled for the other upload jobs, so I can't (well, more like "don't want to") disable throttling via the plex.enabled config entry.