### PR TITLE
Emby Throttle

### DIFF
--- a/cloudplow.py
+++ b/cloudplow.py
@@ -15,6 +15,7 @@ from utils.cache import Cache
 from utils.notifications import Notifications
 from utils.nzbget import Nzbget
 from utils.plex import Plex
+from utils.emby import Emby
 from utils.rclone import RcloneThrottler, RcloneMover
 from utils.syncer import Syncer
 from utils.threads import Thread
@@ -249,10 +250,11 @@ def run_process(task, manager_dict, **kwargs):
 ############################################################
 
 
-@decorators.timed
+# @decorators.timed
 def do_upload(remote=None):
     global plex_monitor_thread, uploader_delay
     global sa_delay
+
 
     nzbget = None
     nzbget_paused = False
@@ -281,10 +283,21 @@ def do_upload(remote=None):
                 if conf.configs['plex']['enabled'] and plex_monitor_thread is None:
                     # Only disable throttling if 'can_be_throttled' is both present in uploader_config and is set to False.
                     if 'can_be_throttled' in uploader_config and not uploader_config['can_be_throttled']:
-                        log.debug("Skipping check for Plex stream due to throttling disabled in remote: %s", uploader_remote)
+                        log.debug("Skipping check for Plex stream due to throttling disabled in remote: %s",
+                                  uploader_remote)
                     # Otherwise, assume throttling is desired.
                     else:
                         plex_monitor_thread = thread.start(do_plex_monitor, 'plex-monitor')
+
+                # start the plex stream monitor before the upload begins, if enabled for both plex and the uploader
+                if conf.configs['emby']['enabled'] and plex_monitor_thread is None:
+                    # Only disable throttling if 'can_be_throttled' is both present in uploader_config and is set to False.
+                    if 'can_be_throttled' in uploader_config and not uploader_config['can_be_throttled']:
+                        log.debug("Skipping check for Emby stream due to throttling disabled in remote: %s",
+                                  uploader_remote)
+                    # Otherwise, assume throttling is desired.
+                    else:
+                        emby_monitor_thread = thread.start(do_emby_monitor, 'emby-monitor')
 
                 # pause the nzbget queue before starting the upload, if enabled
                 if conf.configs['nzbget']['enabled']:
@@ -298,9 +311,11 @@ def do_upload(remote=None):
                 uploader = Uploader(uploader_remote,
                                     uploader_config,
                                     rclone_config,
+                                    conf.configs['plex'],
+                                    conf.configs['emby'],
+                                    conf.configs['rclone'],
                                     conf.configs['core']['rclone_binary_path'],
                                     conf.configs['core']['rclone_config_path'],
-                                    conf.configs['plex'],
                                     conf.configs['core']['dry_run'])
 
                 if sa_delay[uploader_remote] is not None:
@@ -439,6 +454,8 @@ def do_upload(remote=None):
                                             conf.configs['core']['rclone_binary_path'],
                                             conf.configs['core']['rclone_config_path'],
                                             conf.configs['plex'],
+                                            conf.configs['emby'],
+                                            conf.configs['rclone'],
                                             conf.configs['core']['dry_run'])
                         log.info("Move starting from %r -> %r",
                                  uploader_config['mover']['move_from_remote'],
@@ -626,18 +643,18 @@ def do_plex_monitor():
 
     # create the plex object
     plex = Plex(conf.configs['plex']['url'], conf.configs['plex']['token'])
-    if not plex.validate():
-        log.error(
-            "Aborting Plex Media Server stream monitor due to failure to validate supplied server URL and/or Token.")
-        plex_monitor_thread = None
-        return
+    # if not plex.validate():
+    #     log.error(
+    #         "Aborting Plex Media Server stream monitor due to failure to validate supplied server URL and/or Token.")
+    #     plex_monitor_thread = None
+    #     return
 
     # sleep 15 seconds to allow rclone to start
     log.info("Plex Media Server URL + Token were validated. Sleeping for 15 seconds before checking Rclone RC URL.")
     time.sleep(15)
 
     # create the rclone throttle object
-    rclone = RcloneThrottler(conf.configs['plex']['rclone']['url'])
+    rclone = RcloneThrottler(conf.configs['rclone']['url'])
     if not rclone.validate():
         log.error("Aborting Plex Media Server stream monitor due to failure to validate supplied Rclone RC URL.")
         plex_monitor_thread = None
@@ -721,6 +738,105 @@ def do_plex_monitor():
 
     log.info("Finished monitoring Plex stream(s)!")
     plex_monitor_thread = None
+
+@decorators.timed
+def do_emby_monitor():
+    emby = Emby(conf.configs['emby']['url'],conf.configs['emby']['api'])
+    if not emby.validate():
+        log.error(
+            "Aborting Emby Media Server stream monitor due to failure to validate supplied server URL and/or Token.")
+        plex_monitor_thread = None
+        return
+    log.info("Emby + api were validated. Sleeping for 15 seconds before checking Rclone RC URL.")
+    time.sleep(15)
+
+
+    # create the rclone throttle object
+    rclone = RcloneThrottler(conf.configs['rclone']['url'])
+    if not rclone.validate():
+        log.error("Aborting Plex Media Server stream monitor due to failure to validate supplied Rclone RC URL.")
+        plex_monitor_thread = None
+        return
+    else:
+        log.info("Rclone RC URL was validated. Stream monitoring for Plex Media Server will now begin.")
+
+    throttled = False
+    throttle_speed = None
+    lock_file = lock.upload()
+    while lock_file.is_locked():
+        streams = emby.get_streams()
+        if streams is None:
+            log.error("Failed to check Emby Media Server stream(s). Trying again in %d seconds...",
+                      conf.configs['emby']['poll_interval'])
+        else:
+            # we had a response
+            stream_count = 0
+            for stream in streams:
+                stream_count += 1
+
+            # are we already throttled?
+            if ((not throttled or (throttled and not rclone.throttle_active(throttle_speed))) and (
+                    stream_count >= conf.configs['emby']['max_streams_before_throttle'])):
+                log.info("There was %d playing stream(s) on Emby Media Server while it was currently un-throttled.",
+                         stream_count)
+                for stream in streams:
+                    log.info(stream)
+                log.info("Upload throttling will now commence.")
+
+                # send throttle request
+                throttle_speed = misc.get_nearest_less_element(conf.configs['emby']['rclone']['throttle_speeds'],
+                                                               stream_count)
+                throttled = rclone.throttle(throttle_speed)
+
+                # send notification
+                if throttled and conf.configs['emby']['notifications']:
+                    notify.send(
+                        message="Throttled current upload to %s because there was %d playing stream(s) on Emby" %
+                                (throttle_speed, stream_count))
+
+                elif throttled:
+                    if stream_count < conf.configs['emby']['max_streams_before_throttle']:
+                        log.info(
+                            "There was less than %d playing stream(s) on Plex Media Server while it was currently throttled. "
+                            "Removing throttle ...", conf.configs['emby']['max_streams_before_throttle'])
+                        # send un-throttle request
+                        throttled = not rclone.no_throttle()
+                        throttle_speed = None
+
+                        # send notification
+                        if not throttled and conf.configs['emby']['notifications']:
+                            notify.send(
+                                message="Un-throttled current upload because there was less than %d playing stream(s) on "
+                                        "Emby Media Server" % conf.configs['emby']['max_streams_before_throttle'])
+
+                    elif misc.get_nearest_less_element(conf.configs['emby']['rclone']['throttle_speeds'],
+                                                       stream_count) != throttle_speed:
+                        # throttle speed changed, probably due to more/less streams, re-throttle
+                        throttle_speed = misc.get_nearest_less_element(
+                            conf.configs['emby']['rclone']['throttle_speeds'],
+                            stream_count)
+                        log.info("Adjusting throttle speed for current upload to %s because there "
+                                 "was now %d playing stream(s) on Emby Media Server", throttle_speed, stream_count)
+
+                        throttled = rclone.throttle(throttle_speed)
+            #
+                        # send notification
+                        if throttled and conf.configs['emby']['notifications']:
+                            notify.send(
+                                message='Throttle for current upload was adjusted to %s due to %d playing stream(s)'
+                                        ' on Emby Media Server' % (throttle_speed, stream_count))
+
+                    else:
+                        log.info(
+                            "There was %d playing stream(s) on Emby Media Server it was already throttled to %s. Throttling "
+                            "will continue.", stream_count, throttle_speed)
+            #
+                # the lock_file exists, so we can assume an upload is in progress at this point
+                time.sleep(conf.configs['emby']['poll_interval'])
+            #
+    log.info("Finished monitoring Emby stream(s)!")
+    emby_monitor_thread = None
+
 
 
 ############################################################

--- a/cloudplow.py
+++ b/cloudplow.py
@@ -250,7 +250,7 @@ def run_process(task, manager_dict, **kwargs):
 ############################################################
 
 
-# @decorators.timed
+@decorators.timed
 def do_upload(remote=None):
     global plex_monitor_thread, uploader_delay
     global sa_delay
@@ -643,11 +643,11 @@ def do_plex_monitor():
 
     # create the plex object
     plex = Plex(conf.configs['plex']['url'], conf.configs['plex']['token'])
-    # if not plex.validate():
-    #     log.error(
-    #         "Aborting Plex Media Server stream monitor due to failure to validate supplied server URL and/or Token.")
-    #     plex_monitor_thread = None
-    #     return
+    if not plex.validate():
+        log.error(
+            "Aborting Plex Media Server stream monitor due to failure to validate supplied server URL and/or Token.")
+        plex_monitor_thread = None
+        return
 
     # sleep 15 seconds to allow rclone to start
     log.info("Plex Media Server URL + Token were validated. Sleeping for 15 seconds before checking Rclone RC URL.")

--- a/config.json.sample
+++ b/config.json.sample
@@ -24,7 +24,19 @@
         "poll_interval": 60,
         "max_streams_before_throttle": 1,
         "notifications": false,
-        "rclone": {
+     
+    },
+
+    "emby": {
+        "enabled": false,
+        "url": "http://localhost:32400",
+        "api": "",
+        "poll_interval": 60,
+        "max_streams_before_throttle": 1,
+        "notifications": false,  
+    },
+
+   "rclone": {
             "throttle_speeds": {
                 "0": "100M",
                 "1": "50M",
@@ -34,8 +46,7 @@
                 "5": "10M"
             },
             "url": "http://localhost:7949"
-        }
-    },
+        },
     "remotes": {
         "google": {
             "hidden_remote": "google:",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests~=2.20.0
 GitPython~=2.1.10
 sqlitedict~=1.6.0
 apprise~=0.8.2
+

--- a/utils/config.py
+++ b/utils/config.py
@@ -51,15 +51,25 @@ class Config(object):
             'poll_interval': 60,
             'max_streams_before_throttle': 1,
             'notifications': False,
-            'rclone': {
-                'url': 'http://localhost:7949',
-                'throttle_speeds': {
-                    '1': '50M',
-                    '2': '40M',
-                    '3': '30M',
-                    '4': '20M',
-                    '5': '10M'
-                }
+        },
+        # emby
+        'emby': {
+            'enabled': False,
+            'url': 'https://plex.domain.com',
+            'api': '',
+            'poll_interval': 60,
+            'max_streams_before_throttle': 1,
+            'notifications': False,
+        },
+        # rclone settings
+        'rclone': {
+            'url': 'http://localhost:7949',
+            'throttle_speeds': {
+                '1': '50M',
+                '2': '40M',
+                '3': '30M',
+                '4': '20M',
+                '5': '10M'
             }
         },
         # nzbget settings
@@ -360,9 +370,9 @@ class Config(object):
                             )
 
         # Print help by default if no arguments
+        #changed
         if len(sys.argv) == 1:
             parser.print_help()
-
             sys.exit(0)
 
         else:

--- a/utils/emby.py
+++ b/utils/emby.py
@@ -1,0 +1,45 @@
+from urllib.parse import urljoin
+import requests
+import logging
+log = logging.getLogger('emby')
+class Emby():
+    def __init__(self, url, api):
+        self.url = url+'Sessions/?api_key='
+        self.api = api
+    def validate(self):
+        try:
+            request_url = self.url+self.api
+            r = requests.get(request_url, timeout=15, verify=False)
+            if r.status_code == 200:
+                log.debug("Server responded with status_code=%r, content: %r", r.status_code, r.json())
+                return True
+            else:
+                log.error("Server responded with status_code=%r, content: %r", r.status_code, r.content)
+                return False
+        except Exception:
+            log.exception("Exception validating server api=%r, url=%r: ", self.api, self.url)
+            return False
+    def get_streams(self):
+        try:
+            request_url = self.url+self.api
+            r = requests.get(request_url, timeout=15, verify=False)
+            if r.status_code == 200:
+                result = r.json()
+                streams=[]
+                length=len(result)
+                for i in range(0,length):
+                    if(result[i].get("NowPlayingItem")!=None):
+                        streams.append(result[i].get("NowPlayingItem").get("Name"))
+                return streams
+            else:
+                log.error("Error with URL Server responded with status_code=%r, content: %r", r.status_code, r.content)
+                return False
+        except Exception:
+            log.exception("Exception validating server api=%r, url=%r: ", self.api, self.url)
+            return False
+
+
+
+
+
+

--- a/utils/rclone.py
+++ b/utils/rclone.py
@@ -18,12 +18,14 @@ log = logging.getLogger('rclone')
 
 
 class RcloneMover:
-    def __init__(self, config, rclone_binary_path, rclone_config_path, plex, dry_run=False):
+    def __init__(self, config, rclone_binary_path,plex,emby,rclone_throttle, rclone_config_path,dry_run=False):
         self.config = config
         self.rclone_binary_path = rclone_binary_path
         self.rclone_config_path = rclone_config_path
-        self.plex = plex
         self.dry_run = dry_run
+        self.plex=plex
+        self.emby=emby
+        self.rclone_throttle=rclone_throttle
 
     def move(self):
         try:
@@ -41,9 +43,9 @@ class RcloneMover:
             excludes = self.__excludes2string()
             if len(excludes) > 2:
                 cmd += ' %s' % excludes
-            if self.plex.get('enabled'):
+            if self.plex['enabled'] or self.emby['enabled'] :
                 r = re.compile(r"https?://(www\.)?")
-                rc_url = r.sub('', self.plex['rclone']['url']).strip().strip('/')
+                rc_url = r.sub('', self.rclone['url']).strip().strip('/')
                 cmd += ' --rc --rc-addr=%s' % cmd_quote(rc_url)
             if self.dry_run:
                 cmd += ' --dry-run'
@@ -80,13 +82,15 @@ class RcloneMover:
 
 
 class RcloneUploader:
-    def __init__(self, name, config, rclone_binary_path, rclone_config_path, plex, dry_run=False,
+    def __init__(self, name, config,plex,emby,rclone_throttle, rclone_binary_path, rclone_config_path, dry_run=False,
                  service_account=None):
         self.name = name
         self.config = config
+        self.plex=plex
+        self.emby=emby
+        self.rclone_throttle=rclone_throttle
         self.rclone_binary_path = rclone_binary_path
-        self.rclone_config_path = rclone_config_path
-        self.plex = plex
+        self.config_path = rclone_config_path
         self.dry_run = dry_run
         self.service_account = service_account
 
@@ -147,7 +151,7 @@ class RcloneUploader:
                                                    'rclone_command'].lower() != 'sync') else 'move'),
                                                cmd_quote(self.config['upload_folder']),
                                                cmd_quote(self.config['upload_remote']),
-                                               cmd_quote(self.rclone_config_path))
+                                               cmd_quote(self.config_path))
             if self.service_account is not None:
                 cmd += ' --drive-service-account-file %s' % cmd_quote(self.service_account)
             extras = self.__extras2string()
@@ -156,9 +160,9 @@ class RcloneUploader:
             excludes = self.__excludes2string()
             if len(excludes) > 2:
                 cmd += ' %s' % excludes
-            if self.plex.get('enabled'):
+            if self.plex['enabled'] or self.emby['enabled']:
                 r = re.compile(r"https?://(www\.)?")
-                rc_url = r.sub('', self.plex['rclone']['url']).strip().strip('/')
+                rc_url = r.sub('', self.rclone_throttle['url']).strip().strip('/')
                 cmd += ' --rc --rc-addr=%s' % cmd_quote(rc_url)
             if self.dry_run:
                 cmd += ' --dry-run'

--- a/utils/uploader.py
+++ b/utils/uploader.py
@@ -9,16 +9,18 @@ log = logging.getLogger("uploader")
 
 
 class Uploader:
-    def __init__(self, name, uploader_config, rclone_config, rclone_binary_path, rclone_config_path, plex, dry_run):
+    def __init__(self, name, uploader_config, rclone_config,plex,emby,rclone_throttle, rclone_binary_path, rclone_config_path, dry_run):
         self.name = name
         self.uploader_config = uploader_config
         self.rclone_config = rclone_config
+        self.plex=plex
+        self.emby = emby
+        self.rclone_throttle=rclone_throttle
         self.trigger_tracks = {}
         self.delayed_check = 0
         self.delayed_trigger = None
         self.rclone_binary_path = rclone_binary_path
         self.rclone_config_path = rclone_config_path
-        self.plex = plex
         self.dry_run = dry_run
         self.service_account = None
 
@@ -40,11 +42,11 @@ class Uploader:
 
         # do upload
         if self.service_account is not None:
-            rclone = RcloneUploader(self.name, rclone_config, self.rclone_binary_path, self.rclone_config_path,
-                                    self.plex, self.dry_run, self.service_account)
+            rclone = RcloneUploader(self.name, rclone_config,self.plex,self.emby,self.rclone_throttle, self.rclone_binary_path, self.rclone_config_path,
+                                    self.dry_run, self.service_account)
         else:
-            rclone = RcloneUploader(self.name, rclone_config, self.rclone_binary_path, self.rclone_config_path,
-                                    self.plex, self.dry_run)
+            rclone = RcloneUploader(self.name, rclone_config,self.plex,self.emby,self.rclone_throttle, self.rclone_binary_path, self.rclone_config_path,
+                                    self.dry_run)
 
         log.info("Uploading '%s' to remote: %s", rclone_config['upload_folder'], self.name)
         self.delayed_check = 0


### PR DESCRIPTION
This adds a throttle for emby and jellyfin

doing this requires a small change to the config file:moving the rclone section in plex to its own section
Right now the plex_monitor and emby_monitor process work separately.

Redoing these to make them less confusing