### PR TITLE
Add `ignore_local_streams` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Cloudplow has 3 main functions:
     "plex": {
         "enabled": true,
         "max_streams_before_throttle": 1,
+        "ignore_local_streams": true,
         "poll_interval": 60,
         "notifications": false,
         "rclone": {
@@ -551,6 +552,7 @@ Cloudplow can throttle Rclone uploads during active, playing Plex streams (pause
 "plex": {
     "enabled": true,
     "max_streams_before_throttle": 1,
+    "ignore_local_streams": true,
     "poll_interval": 60,
     "notifications": false,
     "rclone": {
@@ -585,6 +587,8 @@ Cloudplow can throttle Rclone uploads during active, playing Plex streams (pause
 `poll_interval` - How often (in seconds) Plex is checked for active streams.
 
 `max_streams_before_throttle` - How many playing streams are allowed before enabling throttling.
+
+`ignore_local_streams` - Whether streaming local files should count for throttling.
 
 `notifications` - Send notifications when throttling is set, adjusted, or unset, depending on stream count.
 

--- a/cloudplow.py
+++ b/cloudplow.py
@@ -659,6 +659,14 @@ def do_plex_monitor():
                 stream.state in ['playing', 'buffering'] and not stream.local
                 for stream in streams
             )
+            local_stream_count = sum(
+                stream.state in ['playing', 'buffering'] and stream.local
+                for stream in streams
+            )
+
+            # if we are accounting for local streams, add them to the stream count
+            if not conf.configs['plex']['ignore_local_streams']:
+                stream_count += local_stream_count
 
             # are we already throttled?
             if ((not throttled or (throttled and not rclone.throttle_active(throttle_speed))) and (

--- a/config.json.sample
+++ b/config.json.sample
@@ -23,6 +23,7 @@
         "token": "",
         "poll_interval": 60,
         "max_streams_before_throttle": 1,
+        "ignore_local_streams": true,
         "notifications": false,
         "rclone": {
             "throttle_speeds": {

--- a/utils/config.py
+++ b/utils/config.py
@@ -50,6 +50,7 @@ class Config(object):
             'token': '',
             'poll_interval': 60,
             'max_streams_before_throttle': 1,
+            'ignore_local_streams': True,
             'notifications': False,
             'rclone': {
                 'url': 'http://localhost:7949',


### PR DESCRIPTION
Following up from #87 – I've gone ahead and rebased on `master`.

---

Howdy folks! 👋

This PR adds configuration to toggle the changes introduced by #74. Closes #86. 

For folks whose streams are affected by the I/O impact of Cloudplow uploads, this allows local streams to optionally count when determining whether Cloudplow should be throttled. The default behavior is to ignore local streams so that throttling behavior will remain the same.

I haven't touched Python in a long time, so feel free to make whatever changes you see fit.

Great work on Cloudplow!
Cheers