### PR TITLE
Fix throttle check logic

### DIFF
--- a/utils/rclone.py
+++ b/utils/rclone.py
@@ -378,7 +378,7 @@ class RcloneThrottler:
                 data = resp.json()
                 if 'error' in data:
                     log.error("Failed to throttle %s: %s", self.url, data['error'])
-                elif 'rate' in data and speed in data['rate']:
+                elif 'rate' in data:
                     log.warning("Successfully throttled %s to %s.", self.url, speed)
                     success = True
 


### PR DESCRIPTION
  - Remove check for speed, no longer returned by rclone

The current master and develop branch has an issue where cloudplow is not recognizing that a throttle has been applied and therefore sends rclone a throttle command during every check when all conditions are met.  The expected behavior is that if cloudplow detects a throttle has already been placed, it does not take an action.  This commit resolves this issue by removing the check on the non-existent speed attribute under rate.  This is not longer there in rclone so the check was causing success to always be false instead of returning true when throttle was applied.